### PR TITLE
Fix Check for identity instead of mere equality

### DIFF
--- a/src/js/Aras/View/Containers/Plugin.js
+++ b/src/js/Aras/View/Containers/Plugin.js
@@ -135,7 +135,7 @@ define([
 					// Prepare Message Text
 					var messagetext = this.Server.ErrorMessage;
 					
-					if (this.Server.ErrorCode == 0)
+					if (this.Server.ErrorCode === 0)
 					{
 						messagetext = 'Unable to connect to Innovator Server';
 					}

--- a/src/js/Aras/View/Window.js
+++ b/src/js/Aras/View/Window.js
@@ -194,7 +194,7 @@ define([
 					// Prepare Message Text
 					var messagetext = this.Server.ErrorMessage;
 					
-					if (this.Server.ErrorCode == 0)
+					if (this.Server.ErrorCode === 0)
 					{
 						messagetext = 'Unable to connect to Innovator Server';
 					}

--- a/src/js/Aras/ViewModel/Control.js
+++ b/src/js/Aras/ViewModel/Control.js
@@ -222,7 +222,7 @@ define([
 			
 			array.forEach(this.Data.Properties, function(property, i){
 					
-				if (property.Type == 0)
+				if (property.Type === 0)
 				{
 					if (this.get(property.Name))
 					{
@@ -233,7 +233,7 @@ define([
 						property.Values[0] = '0';
 					}
 				}
-				else if (property.Type == 3)
+				else if (property.Type === 3)
 				{
 					// Reset Values
 					property.Values = [];
@@ -248,7 +248,7 @@ define([
 						property.Values[0] = this.get(property.Name).ID;
 					}
 				}
-				else if (property.Type == 4)
+				else if (property.Type === 4)
 				{
 					// Get List of Controls from Cache
 					property.Values = [];
@@ -266,7 +266,7 @@ define([
 						
 					}, this);
 				}
-				else if (property.Type == 8)
+				else if (property.Type === 8)
 				{
 					// Date
 					property.Values = [];


### PR DESCRIPTION
Hello,

I think, using the == operator might evaluate to true in situations where you do not want it to so using the === operator would be safer.

It seems better to use "===" for accurate comparison and performance enhancement.

Thanks,